### PR TITLE
Remove destructuring for older node versions

### DIFF
--- a/bin/git-issues
+++ b/bin/git-issues
@@ -95,7 +95,7 @@ GitIssues.fromPath(repoOption.value, statusOption.value, {
     if (labelOption.value) {
       labels = labelOption.value.split(',');
       issues = issues.filter(issue => {
-        var filterLabels = issue.labels.filter((label) => labels.indexOf(label.name) !== -1);
+        var filterLabels = issue.labels.filter(label => labels.indexOf(label.name) !== -1);
         return filterLabels.length > 0;
       });
     }

--- a/bin/git-issues
+++ b/bin/git-issues
@@ -95,7 +95,7 @@ GitIssues.fromPath(repoOption.value, statusOption.value, {
     if (labelOption.value) {
       labels = labelOption.value.split(',');
       issues = issues.filter(issue => {
-        var filterLabels = issue.labels.filter(({name}) => labels.indexOf(name) !== -1);
+        var filterLabels = issue.labels.filter((label) => labels.indexOf(label.name) !== -1);
         return filterLabels.length > 0;
       });
     }


### PR DESCRIPTION
Sorry, I only noticed this was a problem when I installed it on my other computer after you updated :confounded: 